### PR TITLE
feat(telemetry): add distributed heartbeat metrics and centralize attribute keys

### DIFF
--- a/hypercache.go
+++ b/hypercache.go
@@ -1056,6 +1056,22 @@ func (hyperCache *HyperCache[T]) DistRingHashSpots() []string { //nolint:ireturn
 	return nil
 }
 
+// DistHeartbeatMetrics returns distributed heartbeat metrics if supported.
+func (hyperCache *HyperCache[T]) DistHeartbeatMetrics() any { //nolint:ireturn
+	if dm, ok := any(hyperCache.backend).(*backend.DistMemory); ok {
+		m := dm.Metrics()
+
+		return map[string]any{
+			"heartbeatSuccess":   m.HeartbeatSuccess,
+			"heartbeatFailure":   m.HeartbeatFailure,
+			"nodesRemoved":       m.NodesRemoved,
+			"readPrimaryPromote": m.ReadPrimaryPromote,
+		}
+	}
+
+	return nil
+}
+
 // ManagementHTTPAddress returns the bound address of the optional management HTTP server.
 // Empty string when the server is disabled or failed to start.
 func (hyperCache *HyperCache[T]) ManagementHTTPAddress() string {

--- a/internal/telemetry/attrs/keys.go
+++ b/internal/telemetry/attrs/keys.go
@@ -1,8 +1,7 @@
-// Package attrs provides reusable OpenTelemetry attribute key constants
-// to avoid duplication across middlewares.
-// Package attrs defines telemetry attribute keys used for observability and monitoring
-// across the hypercache system. These constants provide standardized key names for
-// metrics, traces, and logs to ensure consistent telemetry data collection.
+// Package attrs provides reusable OpenTelemetry attribute key constants to avoid duplication
+// across middlewares. It defines telemetry attribute keys used for observability and monitoring
+// across the hypercache system. These constants provide standardized key names for metrics,
+// traces, and logs to ensure consistent telemetry data collection.
 package attrs
 
 const (

--- a/internal/telemetry/attrs/keys.go
+++ b/internal/telemetry/attrs/keys.go
@@ -1,0 +1,29 @@
+// Package attrs provides reusable OpenTelemetry attribute key constants
+// to avoid duplication across middlewares.
+// Package attrs defines telemetry attribute keys used for observability and monitoring
+// across the hypercache system. These constants provide standardized key names for
+// metrics, traces, and logs to ensure consistent telemetry data collection.
+package attrs
+
+const (
+	// AttrKeyLength represents the telemetry attribute key for measuring the length
+	// of a cache key in bytes. This metric helps monitor key size distribution
+	// and identify potential performance impacts from oversized keys.
+	AttrKeyLength = "key.len"
+	// AttrKeysCount represents the telemetry attribute key for measuring the number
+	// of cache keys being processed. This metric helps monitor the workload and
+	// identify potential bottlenecks in key management.
+	AttrKeysCount = "keys.count"
+	// AttrResultCount represents the telemetry attribute key for measuring the number
+	// of cache results returned. This metric helps monitor the effectiveness of cache
+	// lookups and identify potential issues with cache population.
+	AttrResultCount = "result.count"
+	// AttrFailedCount represents the telemetry attribute key for measuring the number
+	// of cache operations that failed. This metric helps monitor error rates and
+	// identify potential issues with cache reliability.
+	AttrFailedCount = "failed.count"
+	// AttrExpirationMS represents the telemetry attribute key for measuring the expiration
+	// time of cache items in milliseconds. This metric helps monitor cache item lifetimes
+	// and identify potential issues with cache eviction policies.
+	AttrExpirationMS = "expiration.ms"
+)

--- a/management_http.go
+++ b/management_http.go
@@ -102,6 +102,7 @@ type membershipIntrospect interface {
 		vnodes int,
 	)
 	DistRingHashSpots() []string
+	DistHeartbeatMetrics() any
 }
 
 // Start launches listener (idempotent). Caller provides cache for handler wiring.
@@ -255,6 +256,13 @@ func (s *ManagementHTTPServer) registerCluster(useAuth func(fiber.Handler) fiber
 			spots := mi.DistRingHashSpots()
 
 			return fiberCtx.JSON(fiber.Map{"count": len(spots), "vnodes": spots})
+		}
+
+		return fiberCtx.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "distributed backend unsupported"})
+	}))
+	s.app.Get("/cluster/heartbeat", useAuth(func(fiberCtx fiber.Ctx) error { // heartbeat metrics
+		if mi, ok := hc.(membershipIntrospect); ok {
+			return fiberCtx.JSON(mi.DistHeartbeatMetrics())
 		}
 
 		return fiberCtx.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "distributed backend unsupported"})

--- a/pkg/backend/dist_http_server.go
+++ b/pkg/backend/dist_http_server.go
@@ -55,12 +55,13 @@ func (s *distHTTPServer) registerSet(ctx context.Context, dm *DistMemory) { //no
 			return fctx.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": unmarshalErr.Error()})
 		}
 
-		it := &cache.Item{
-			Key:        req.Key,
-			Value:      req.Value,
-			Expiration: time.Duration(req.Expiration) * time.Millisecond,
-			Version:    req.Version,
-			Origin:     req.Origin,
+		it := &cache.Item{ // LastUpdated set to now for replicated writes
+			Key:         req.Key,
+			Value:       req.Value,
+			Expiration:  time.Duration(req.Expiration) * time.Millisecond,
+			Version:     req.Version,
+			Origin:      req.Origin,
+			LastUpdated: time.Now(),
 		}
 
 		dm.applySet(ctx, it, req.Replicate)

--- a/pkg/backend/dist_http_transport.go
+++ b/pkg/backend/dist_http_transport.go
@@ -183,11 +183,12 @@ func decodeGetBody(r io.Reader) (*cache.Item, bool, error) { //nolint:ireturn
 		}
 		// reconstruct cache.Item (we ignore expiration formatting difference vs ms)
 		return &cache.Item{ // multi-line for readability
-			Key:        mirror.Key,
-			Value:      mirror.Value,
-			Expiration: time.Duration(mirror.Expiration) * time.Millisecond,
-			Version:    mirror.Version,
-			Origin:     mirror.Origin,
+			Key:         mirror.Key,
+			Value:       mirror.Value,
+			Expiration:  time.Duration(mirror.Expiration) * time.Millisecond,
+			Version:     mirror.Version,
+			Origin:      mirror.Origin,
+			LastUpdated: time.Now(),
 		}, true, nil
 	}
 

--- a/pkg/backend/dist_memory.go
+++ b/pkg/backend/dist_memory.go
@@ -253,9 +253,10 @@ func (dm *DistMemory) Set(ctx context.Context, item *cache.Item) error { //nolin
 		}
 	}
 
-	// primary path: assign version
+	// primary path: assign version & timestamp
 	item.Version = atomic.AddUint64(&dm.versionCounter, 1)
 	item.Origin = string(dm.localNode.ID)
+	item.LastUpdated = time.Now()
 	dm.applySet(ctx, item, false)
 
 	acks := 1 + dm.replicateTo(ctx, item, owners[1:])

--- a/pkg/cache/v2/item.go
+++ b/pkg/cache/v2/item.go
@@ -62,6 +62,7 @@ type Item struct {
 	Key         string        // key of the item
 	Value       any           // value of the item
 	LastAccess  time.Time     // last access time
+	LastUpdated time.Time     // last write/version assignment time (distributed usage)
 	Size        int64         // size in bytes
 	Expiration  time.Duration // expiration duration
 	AccessCount uint32        // number of times the item has been accessed


### PR DESCRIPTION
- Add DistHeartbeatMetrics() method to expose heartbeat success/failure, nodes removed, and read primary promote metrics
- Create internal/telemetry/attrs package to centralize OpenTelemetry attribute key constants
- Add /cluster/heartbeat endpoint to management HTTP server for heartbeat metrics access
- Update cache Item struct with LastUpdated field for distributed usage tracking
- Set LastUpdated timestamp for replicated writes and version assignments
- Refactor OTel middleware to use centralized attribute constants from attrs package

This change improves observability for distributed cache operations and reduces code duplication by centralizing telemetry attribute definitions.