### PR TITLE
docs(ci): add .nojekyll and clarify GitHub Pages setup requirement

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,14 @@ name: docs
 #   * push to main — build + deploy to gh-pages.
 #   * workflow_dispatch — same as push (lets operators
 #     re-publish without a docs change).
+#
+# REPO SETUP REQUIRED — Settings → Pages → Source must be
+# "GitHub Actions" (NOT "Deploy from a branch"). The
+# branch-based default runs Jekyll on the main branch and
+# fails because docs/ uses MkDocs's `{% include-markdown %}`
+# syntax which Jekyll's `include` tag doesn't grok. The
+# repo-root `.nojekyll` file is a defensive fallback that
+# stops Jekyll from running even if the setting reverts.
 
 on:
   pull_request:


### PR DESCRIPTION
Add a \`.nojekyll\` file at the repo root to prevent Jekyll from processing the MkDocs-based docs site, which uses \`{% include-markdown %}\` syntax incompatible with Jekyll's \`include\` tag.

Extend the \`docs.yml\` workflow header comment to document that the GitHub Pages source must be configured to "GitHub Actions" rather than "Deploy from a branch" to avoid build failures.