### PR TITLE
feat(mgmt): add SSE endpoint for live cluster topology events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`GET /cluster/events` — SSE stream of topology updates.** New
+  Server-Sent Events endpoint on the management HTTP port that
+  pushes `members` (full membership snapshot) and `heartbeat`
+  (counters snapshot) frames to subscribers, replacing the
+  monitor's 2-second poll cadence with a live stream. Connect-time
+  frames carry the current snapshot so a fresh subscriber doesn't
+  wait for the next mutation. The cache wires an in-process
+  broadcaster ([`internal/eventbus`](internal/eventbus/bus.go))
+  that drops events for slow consumers (per-subscriber bounded
+  buffer) so the SWIM heartbeat loop never backpressures on a
+  stuck operator's browser. Membership state changes propagate via
+  the new [`Membership.OnStateChange`](internal/cluster/membership.go)
+  observer hook; heartbeat snapshots tick at 1 Hz aligned with
+  the SWIM interval. Read-scope auth (matches existing
+  `/cluster/*` routes); honors the management server's lifecycle
+  context for graceful drain on `Stop()`.
+
+### Changed
+
+- **Management server `defaultWriteTimeout` 5 s → 0 (no cap).**
+  fasthttp resets WriteTimeout per response; the 5 s default
+  force-closed the new SSE stream at exactly that mark, the
+  consumer saw "other side closed", and the monitor fell back
+  to polling. Lifting the cap is safe for the mgmt port because
+  it's internal-only and JSON handlers complete in milliseconds;
+  idle keep-alive connections are still bounded by the 60 s
+  IdleTimeout. Operators who need a write cap can opt in via
+  [`WithMgmtWriteTimeout`](management_http.go).
+  Regression-pinned by `TestManagementHTTP_ClusterEvents`, which
+  reads frames for 6 s past the historic deadline.
 - **Per-route scope enforcement on the management HTTP port.**
   `WithMgmtControlAuth` is a new option that wraps the cluster-
   mutating control endpoints (`POST /evict`, `POST /clear`,

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -40,6 +40,7 @@ words:
   - assertable
   - autosync
   - backpressure
+  - backpressures
   - baselining
   - benchmarkdist
   - benchmem
@@ -49,6 +50,7 @@ words:
   - bodyclose
   - bufbuild
   - buildx
+  - bursty
   - cacheerrors
   - cachev
   - calledback
@@ -80,6 +82,7 @@ words:
   - Equalf
   - errcheck
   - errp
+  - eventbus
   - ewrap
   - excalidraw
   - excludeonly
@@ -230,6 +233,8 @@ words:
   - unmarshals
   - unpadded
   - unsharded
+  - unsub
+  - unsubbed
   - upserted
   - upserts
   - varnamelen

--- a/hypercache_dist.go
+++ b/hypercache_dist.go
@@ -3,8 +3,27 @@ package hypercache
 import (
 	"context"
 
+	"github.com/hyp3rd/hypercache/internal/eventbus"
 	"github.com/hyp3rd/hypercache/pkg/backend"
 )
+
+// EventBus returns the in-process broadcaster the distributed
+// backend uses to publish topology changes (`members`,
+// `heartbeat`). Returns nil when the backend is not DistMemory —
+// the management HTTP server's SSE handler treats nil as
+// "streaming unsupported" and falls back to a 503.
+//
+// The bus is owned by DistMemory and lives until the backend's
+// lifecycle context is cancelled. SSE handlers Subscribe via the
+// request context so they're reaped when either the client
+// disconnects or the cache shuts down.
+func (hyperCache *HyperCache[T]) EventBus() *eventbus.Bus {
+	if dm, ok := any(hyperCache.backend).(*backend.DistMemory); ok {
+		return dm.EventBus()
+	}
+
+	return nil
+}
 
 // DistMetrics returns distributed backend metrics if the underlying backend is DistMemory.
 // Returns nil if unsupported.

--- a/internal/cluster/membership.go
+++ b/internal/cluster/membership.go
@@ -7,16 +7,53 @@ import (
 	"time"
 )
 
+// StateChangeObserver is invoked AFTER a membership mutation
+// (Upsert / Mark / Remove) commits, with the membership lock
+// already released. Observers MUST NOT call back into the
+// Membership they were registered on (deadlock); they SHOULD do
+// minimal work (publish to a channel, increment a counter) and
+// return promptly, since multiple observers run sequentially on
+// the goroutine that performed the mutation.
+//
+// Phase C SSE: the cache binary registers one observer that
+// publishes a `members` event onto the in-process event bus, so
+// SSE subscribers see state transitions without re-deriving them
+// by polling.
+type StateChangeObserver func(id NodeID, state NodeState, version uint64)
+
 // Membership tracks current cluster nodes (static MVP, future: gossip/swim).
 type Membership struct {
-	mu    sync.RWMutex
-	nodes map[NodeID]*Node
-	ring  *Ring
-	ver   MembershipVersion
+	mu        sync.RWMutex
+	nodes     map[NodeID]*Node
+	ring      *Ring
+	ver       MembershipVersion
+	observers []StateChangeObserver
 }
 
 // NewMembership creates a new membership container bound to a ring.
 func NewMembership(ring *Ring) *Membership { return &Membership{nodes: map[NodeID]*Node{}, ring: ring} }
+
+// OnStateChange registers a callback invoked after every membership
+// mutation (Upsert, Mark, Remove). Registration is append-only and
+// not safe for concurrent use with mutations — call this once at
+// construction before the cache starts driving heartbeats / gossip.
+//
+// The callback runs OUTSIDE the membership lock so a slow observer
+// does not block the SWIM heartbeat loop. Observers fire in
+// registration order; one panicking observer would skip every
+// observer registered after it, so observer authors must recover
+// in their own code (the package itself does not wrap with
+// recover() because that would mask programming bugs).
+func (m *Membership) OnStateChange(fn StateChangeObserver) {
+	if fn == nil {
+		return
+	}
+
+	m.mu.Lock()
+
+	m.observers = append(m.observers, fn)
+	m.mu.Unlock()
+}
 
 // Upsert adds or updates a node and rebuilds ring.
 func (m *Membership) Upsert(n *Node) {
@@ -32,10 +69,14 @@ func (m *Membership) Upsert(n *Node) {
 		}
 	}
 
-	m.ver.Next()
+	version := m.ver.Next()
+	observers := m.observers
+	id := n.ID
+	state := n.State
 	m.mu.Unlock()
 
 	m.ring.Build(nodes)
+	notify(observers, id, state, version)
 }
 
 // List returns current nodes snapshot.
@@ -80,10 +121,15 @@ func (m *Membership) Remove(id NodeID) bool {
 		}
 	}
 
-	m.ver.Next()
+	version := m.ver.Next()
+	observers := m.observers
 	m.mu.Unlock()
 
 	m.ring.Build(nodes)
+	// State NodeDead represents "removed from membership" for
+	// observer purposes; the node is gone from the map and will
+	// not appear in any subsequent List() call.
+	notify(observers, id, NodeDead, version)
 
 	return true
 }
@@ -93,18 +139,34 @@ func (m *Membership) Mark(id NodeID, state NodeState) bool {
 	m.mu.Lock()
 
 	n, ok := m.nodes[id]
-	if ok {
-		n.State = state
-		n.Incarnation++
+	if !ok {
+		m.mu.Unlock()
 
-		n.LastSeen = time.Now()
-
-		m.ver.Next()
+		return false
 	}
+
+	n.State = state
+	n.Incarnation++
+
+	n.LastSeen = time.Now()
+
+	version := m.ver.Next()
+	observers := m.observers
 
 	m.mu.Unlock()
 
-	return ok
+	notify(observers, id, state, version)
+
+	return true
+}
+
+// notify invokes each observer in registration order with the
+// resolved state and version. Pulled out so the call sites read
+// "mutate, unlock, notify" uniformly without inline loops.
+func notify(observers []StateChangeObserver, id NodeID, state NodeState, version uint64) {
+	for _, fn := range observers {
+		fn(id, state, version)
+	}
 }
 
 // Version returns current membership version.

--- a/internal/cluster/membership_test.go
+++ b/internal/cluster/membership_test.go
@@ -1,0 +1,213 @@
+package cluster
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestMembership_OnStateChange_FiresAfterMutation pins the
+// "observers run AFTER the lock is released and the mutation is
+// committed" contract. An observer reading via List() must see
+// the new state, not the pre-mutation state — verifying we don't
+// invoke observers from inside the mutex.
+func TestMembership_OnStateChange_FiresAfterMutation(t *testing.T) {
+	t.Parallel()
+
+	m := NewMembership(NewRing())
+	m.Upsert(NewNode("n1", "127.0.0.1:7946"))
+
+	var (
+		seenState   NodeState
+		seenVersion uint64
+		seenList    []*Node
+	)
+
+	m.OnStateChange(func(_ NodeID, state NodeState, version uint64) {
+		seenState = state
+		seenVersion = version
+		// List() takes the membership read-lock. If observers
+		// were invoked from inside the write lock, this would
+		// deadlock. The test passing means the lock IS released
+		// before observers fire.
+		seenList = m.List()
+	})
+
+	m.Mark("n1", NodeSuspect)
+
+	if seenState != NodeSuspect {
+		t.Errorf("observer state: got %v, want NodeSuspect", seenState)
+	}
+
+	if seenVersion == 0 {
+		t.Errorf("observer version: got 0, want > 0")
+	}
+
+	if len(seenList) != 1 || seenList[0].State != NodeSuspect {
+		t.Errorf("observer list reflects pre-mutation state; got %+v", seenList)
+	}
+}
+
+// TestMembership_OnStateChange_FiresOnUpsertAndRemove covers the
+// non-Mark mutation paths. Upsert is the gossip-driven
+// "node-discovered" path; Remove is the "post-deadAfter prune"
+// path. Both must reach observers so an SSE consumer sees the
+// full lifecycle, not just suspect/alive transitions.
+func TestMembership_OnStateChange_FiresOnUpsertAndRemove(t *testing.T) {
+	t.Parallel()
+
+	m := NewMembership(NewRing())
+
+	type seen struct {
+		id      NodeID
+		state   NodeState
+		version uint64
+	}
+
+	var events []seen
+
+	m.OnStateChange(func(id NodeID, state NodeState, version uint64) {
+		events = append(events, seen{id, state, version})
+	})
+
+	m.Upsert(NewNode("n1", "127.0.0.1:7946"))
+	m.Mark("n1", NodeSuspect)
+	m.Remove("n1")
+
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3 (upsert+mark+remove)", len(events))
+	}
+
+	wantStates := []NodeState{NodeAlive, NodeSuspect, NodeDead}
+	for i, e := range events {
+		if e.id != "n1" {
+			t.Errorf("event %d: id %q, want n1", i, e.id)
+		}
+
+		if e.state != wantStates[i] {
+			t.Errorf("event %d: state %v, want %v", i, e.state, wantStates[i])
+		}
+
+		if i > 0 && e.version <= events[i-1].version {
+			t.Errorf("event %d: version %d not > previous %d", i, e.version, events[i-1].version)
+		}
+	}
+}
+
+// TestMembership_OnStateChange_NoEventOnNoOpMark guards against
+// emitting events for mutations that didn't actually mutate.
+// Marking a non-existent node returns false and must NOT fire
+// observers — an SSE consumer would otherwise see ghost
+// "transitioned to suspect" events for nodes that never existed.
+func TestMembership_OnStateChange_NoEventOnNoOpMark(t *testing.T) {
+	t.Parallel()
+
+	m := NewMembership(NewRing())
+
+	var fired atomic.Int32
+
+	m.OnStateChange(func(_ NodeID, _ NodeState, _ uint64) {
+		fired.Add(1)
+	})
+
+	if m.Mark("ghost", NodeSuspect) {
+		t.Fatal("Mark on non-existent node returned true")
+	}
+
+	if got := fired.Load(); got != 0 {
+		t.Errorf("observer fired %d times for no-op Mark, want 0", got)
+	}
+
+	// Same shape for a no-op Remove.
+	if m.Remove("ghost") {
+		t.Fatal("Remove on non-existent node returned true")
+	}
+
+	if got := fired.Load(); got != 0 {
+		t.Errorf("observer fired %d times for no-op Remove, want 0", got)
+	}
+}
+
+// TestMembership_OnStateChange_MultipleObservers covers the
+// fan-out path — multiple registered observers all see every
+// mutation, in registration order. The cache binary registers
+// (1) the SSE event-bus publisher and (2) potentially metrics
+// counters; both need to fire on every event.
+func TestMembership_OnStateChange_MultipleObservers(t *testing.T) {
+	t.Parallel()
+
+	m := NewMembership(NewRing())
+	m.Upsert(NewNode("n1", "127.0.0.1:7946"))
+
+	var firstCalls, secondCalls int32
+
+	m.OnStateChange(func(_ NodeID, _ NodeState, _ uint64) {
+		atomic.AddInt32(&firstCalls, 1)
+	})
+	m.OnStateChange(func(_ NodeID, _ NodeState, _ uint64) {
+		atomic.AddInt32(&secondCalls, 1)
+	})
+
+	m.Mark("n1", NodeSuspect)
+	m.Mark("n1", NodeAlive)
+
+	if got := atomic.LoadInt32(&firstCalls); got != 2 {
+		t.Errorf("first observer: %d calls, want 2", got)
+	}
+
+	if got := atomic.LoadInt32(&secondCalls); got != 2 {
+		t.Errorf("second observer: %d calls, want 2", got)
+	}
+}
+
+// TestMembership_OnStateChange_DoesNotBlockMutation pins the
+// "slow observer doesn't backpressure the heartbeat loop" claim.
+// Mutation must complete (and Version() must reflect the new
+// value) before the observer's blocking work finishes.
+//
+// The Membership package itself doesn't promise the observer is
+// async — but it DOES promise the lock is released before the
+// observer runs. So a different goroutine acquiring the lock
+// during the slow observer must succeed without waiting on the
+// observer.
+func TestMembership_OnStateChange_DoesNotBlockMutation(t *testing.T) {
+	t.Parallel()
+
+	m := NewMembership(NewRing())
+	m.Upsert(NewNode("n1", "127.0.0.1:7946"))
+
+	releaseObserver := make(chan struct{})
+	observerEntered := make(chan struct{})
+	// Observer fires on every mutation; only the FIRST invocation
+	// should block. Subsequent invocations (e.g. the concurrent
+	// Upsert below) must return promptly so the test's own
+	// orchestration mutations don't deadlock.
+	var fired atomic.Int32
+
+	m.OnStateChange(func(_ NodeID, _ NodeState, _ uint64) {
+		if fired.Add(1) == 1 {
+			close(observerEntered)
+			<-releaseObserver
+		}
+	})
+
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		m.Mark("n1", NodeSuspect)
+	})
+
+	<-observerEntered // observer is now stuck on the Mark call
+
+	// While the observer blocks, another mutation should still
+	// be able to take the lock — proving the lock isn't held
+	// during observer invocation.
+	m.Upsert(NewNode("n2", "127.0.0.1:7947"))
+
+	if len(m.List()) != 2 {
+		t.Errorf("expected 2 nodes after concurrent Upsert, got %d", len(m.List()))
+	}
+
+	close(releaseObserver)
+	wg.Wait()
+}

--- a/internal/eventbus/bus.go
+++ b/internal/eventbus/bus.go
@@ -1,0 +1,169 @@
+// Package eventbus is a small in-process fan-out broadcaster used
+// by the management HTTP server's SSE endpoint to push topology
+// updates to every connected operator.
+//
+// Design points:
+//
+//   - **Drop-on-full publish.** Each subscriber owns a small
+//     buffered channel. If a subscriber is slow and its buffer
+//     fills, Publish DROPS the event for that subscriber rather
+//     than blocking — the SWIM heartbeat loop publishes events
+//     and must never wait on an unresponsive consumer. Subscribers
+//     can detect drops via the Dropped() counter and reconnect to
+//     get a fresh snapshot.
+//
+//   - **Context-driven unsubscribe.** Subscribe takes a context;
+//     when the context cancels, the bus reaps the subscription
+//     and closes the channel. Callers MUST drain the channel after
+//     ctx cancellation to avoid leaking goroutines blocked on
+//     send (the bus uses non-blocking send, but a half-buffered
+//     channel still has buffered values).
+//
+//   - **No external deps.** Pure stdlib (sync, sync/atomic).
+//     Testable in isolation.
+//
+// Out of scope: persistence, replay, fan-in, cross-process
+// distribution. This is the simplest thing that works for the
+// monitor's SSE consumer.
+package eventbus
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Event is the payload carried over the bus. Type names the event
+// shape ("members" or "heartbeat" today; new types are additive),
+// Payload is the wire JSON the SSE handler will marshal, and
+// Version is the bus-monotonic ordering so subscribers can detect
+// gaps caused by drops.
+type Event struct {
+	Type      string
+	Payload   any
+	Version   uint64
+	Timestamp time.Time
+}
+
+// subscriberBufferSize bounds each subscriber's queue. Larger →
+// more memory per slow consumer; smaller → more drops on bursty
+// emit. 16 is generous for SWIM-driven event rates (a few per
+// second at most for a 100-node cluster).
+const subscriberBufferSize = 16
+
+// Bus is a fan-out broadcaster. The zero value is NOT usable —
+// always construct via New().
+type Bus struct {
+	mu          sync.RWMutex
+	subscribers map[uint64]*subscriber
+	nextID      uint64
+	version     atomic.Uint64
+	dropped     atomic.Uint64
+}
+
+type subscriber struct {
+	ch chan Event
+}
+
+// New constructs an empty Bus.
+func New() *Bus {
+	return &Bus{subscribers: make(map[uint64]*subscriber)}
+}
+
+// Subscribe registers a new subscriber. Returns a receive-only
+// channel of events and an Unsubscribe function. The subscription
+// is also reaped automatically when ctx is canceled (typical
+// shape: caller derives ctx from the request context, the bus
+// cleans up when the request ends).
+//
+// Callers SHOULD call the returned unsubscribe function in a
+// defer; ctx-driven reaping is the safety net for when the
+// caller's defer runs late or panics. Calling unsubscribe
+// twice is safe (idempotent).
+func (b *Bus) Subscribe(ctx context.Context) (<-chan Event, func()) {
+	b.mu.Lock()
+
+	id := b.nextID
+	b.nextID++
+
+	sub := &subscriber{ch: make(chan Event, subscriberBufferSize)}
+
+	b.subscribers[id] = sub
+	b.mu.Unlock()
+
+	var once sync.Once
+
+	unsub := func() {
+		once.Do(func() {
+			b.mu.Lock()
+			delete(b.subscribers, id)
+			b.mu.Unlock()
+			close(sub.ch)
+		})
+	}
+
+	// Goroutine that watches ctx; runs until either ctx cancels
+	// (then we unsub) or someone else has already unsubbed (then
+	// the goroutine exits via the closed channel write inside
+	// once.Do — actually, ctx.Done() being a channel means we
+	// just block until cancellation; the once.Do guards the
+	// double-unsub case).
+	go func() {
+		<-ctx.Done()
+		unsub()
+	}()
+
+	return sub.ch, unsub
+}
+
+// Publish broadcasts evt to every current subscriber. The publish
+// is fire-and-forget: if a subscriber's buffer is full, the event
+// is dropped for that subscriber and the global drop counter
+// increments. Returns the version assigned to the event (useful
+// for tests pinning ordering).
+//
+// Publish does NOT block on slow subscribers — by design the
+// SWIM heartbeat goroutine drives publishes and must keep ticking
+// at its configured interval regardless of consumer health.
+func (b *Bus) Publish(evt Event) uint64 {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	// Stamp the event under the read lock so version is
+	// monotonic across concurrent publishers.
+	version := b.version.Add(1)
+
+	evt.Version = version
+
+	if evt.Timestamp.IsZero() {
+		evt.Timestamp = time.Now()
+	}
+
+	for _, sub := range b.subscribers {
+		select {
+		case sub.ch <- evt:
+		default:
+			b.dropped.Add(1)
+		}
+	}
+
+	return version
+}
+
+// Dropped returns the cumulative count of events dropped because a
+// subscriber's buffer was full. Used for telemetry / sanity checks
+// in tests; not part of the SSE wire format.
+func (b *Bus) Dropped() uint64 {
+	return b.dropped.Load()
+}
+
+// SubscriberCount returns the number of currently registered
+// subscribers. Useful for tests asserting clean unsubscribe
+// behavior on context cancellation.
+func (b *Bus) SubscriberCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return len(b.subscribers)
+}

--- a/internal/eventbus/bus_test.go
+++ b/internal/eventbus/bus_test.go
@@ -1,0 +1,306 @@
+package eventbus
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// testEventType is a sentinel event-type string used across the
+// test bodies. Hoisted to satisfy goconst — it would otherwise
+// repeat 9× across the file with no semantic significance.
+const testEventType = "members"
+
+// TestBus_PublishToSingleSubscriber covers the smoke path —
+// Subscribe, Publish, receive on the channel. Pins the basics so
+// any future refactor that breaks "the simplest case" trips
+// loudly.
+func TestBus_PublishToSingleSubscriber(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	defer cancel()
+
+	ch, unsub := b.Subscribe(ctx)
+	defer unsub()
+
+	v := b.Publish(Event{Type: testEventType, Payload: "hello"})
+
+	select {
+	case got := <-ch:
+		if got.Type != testEventType {
+			t.Errorf("type: got %q, want members", got.Type)
+		}
+
+		if got.Version != v {
+			t.Errorf("version: got %d, want %d", got.Version, v)
+		}
+
+		if got.Payload != "hello" {
+			t.Errorf("payload: got %v, want hello", got.Payload)
+		}
+
+		if got.Timestamp.IsZero() {
+			t.Errorf("timestamp not stamped")
+		}
+
+	case <-time.After(time.Second):
+		t.Fatal("did not receive event within 1s")
+	}
+}
+
+// TestBus_FanOutToMultipleSubscribers pins the "every subscriber
+// sees every event" property. The SSE handler relies on this: two
+// operators on /topology each open their own subscription and
+// both must observe the same membership transitions.
+func TestBus_FanOutToMultipleSubscribers(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	defer cancel()
+
+	ch1, unsub1 := b.Subscribe(ctx)
+	defer unsub1()
+
+	ch2, unsub2 := b.Subscribe(ctx)
+
+	defer unsub2()
+
+	b.Publish(Event{Type: testEventType})
+
+	for i, ch := range []<-chan Event{ch1, ch2} {
+		select {
+		case got := <-ch:
+			if got.Type != testEventType {
+				t.Errorf("ch%d: type %q, want members", i+1, got.Type)
+			}
+
+		case <-time.After(time.Second):
+			t.Fatalf("ch%d did not receive event within 1s", i+1)
+		}
+	}
+}
+
+// TestBus_DropsOnFullBuffer is the load-bearing assertion: a slow
+// subscriber MUST NOT block the bus. We fill the buffer (size 16),
+// then publish more events; the slow subscriber misses them but
+// publish never blocks and the drop counter increments.
+func TestBus_DropsOnFullBuffer(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	defer cancel()
+
+	_, unsub := b.Subscribe(ctx)
+	defer unsub()
+
+	// Fill the buffer.
+	for range subscriberBufferSize {
+		b.Publish(Event{Type: testEventType})
+	}
+
+	if got := b.Dropped(); got != 0 {
+		t.Errorf("Dropped after filling buffer: got %d, want 0", got)
+	}
+
+	// Buffer is now full; further publishes drop.
+	const overflow = 5
+
+	for range overflow {
+		b.Publish(Event{Type: testEventType})
+	}
+
+	if got := b.Dropped(); got != overflow {
+		t.Errorf("Dropped after overflow: got %d, want %d", got, overflow)
+	}
+}
+
+// TestBus_SlowSubscriberDoesNotBlockFastOne pins the fan-out
+// fairness property: a slow consumer's full buffer drops its OWN
+// events, but the fast consumer keeps receiving. Without this,
+// one stuck operator on /topology would silently freeze every
+// other operator's view.
+//
+// The publish-then-drain handshake matters here: we publish ONE
+// event, wait for the fast consumer to drain it, then publish
+// the next. Without the handshake, scheduler luck determines
+// whether the fast consumer's buffer also overflows — which would
+// be a flaky test, not a real bus bug.
+func TestBus_SlowSubscriberDoesNotBlockFastOne(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	defer cancel()
+
+	// Slow subscriber — never reads.
+	_, unsubSlow := b.Subscribe(ctx)
+	defer unsubSlow()
+
+	// Fast subscriber — drains synchronously via a 1-deep ack
+	// channel so the test can publish at the consumer's pace.
+	chFast, unsubFast := b.Subscribe(ctx)
+	defer unsubFast()
+
+	const n = subscriberBufferSize + 10 // enough to overflow slow's buffer
+
+	ack := make(chan struct{})
+
+	go func() {
+		for range chFast {
+			ack <- struct{}{}
+		}
+	}()
+
+	for i := range n {
+		b.Publish(Event{Type: testEventType})
+
+		// Wait for the fast consumer to drain this publish so
+		// its buffer never accumulates. The slow subscriber's
+		// buffer fills regardless because nobody reads it.
+		select {
+		case <-ack:
+		case <-time.After(time.Second):
+			t.Fatalf("fast subscriber did not ack publish %d within 1s", i)
+		}
+	}
+
+	// Slow subscriber dropped 10 (n - bufferSize).
+	if dropped := b.Dropped(); dropped != n-subscriberBufferSize {
+		t.Errorf("Dropped: got %d, want %d", dropped, n-subscriberBufferSize)
+	}
+}
+
+// TestBus_UnsubscribeIsIdempotent guards the defer-and-explicit-
+// unsubscribe pattern callers use (defer unsub() AND explicit
+// reaping via ctx). Both paths must not double-close the channel.
+func TestBus_UnsubscribeIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	defer cancel()
+
+	_, unsub := b.Subscribe(ctx)
+	unsub()
+	// Second call must not panic.
+	unsub()
+	unsub()
+
+	if c := b.SubscriberCount(); c != 0 {
+		t.Errorf("SubscriberCount after unsub: got %d, want 0", c)
+	}
+}
+
+// TestBus_ContextCancellationReapsSubscription pins the safety-net
+// path: even if the caller forgets to call unsubscribe, the ctx
+// cancellation cleans up the subscription and closes the channel.
+func TestBus_ContextCancellationReapsSubscription(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	ch, _ := b.Subscribe(ctx)
+
+	if c := b.SubscriberCount(); c != 1 {
+		t.Errorf("SubscriberCount after Subscribe: got %d, want 1", c)
+	}
+
+	cancel()
+
+	// Wait for the cleanup goroutine to run. A polling loop is
+	// the simplest cross-platform synchronization here — a sync
+	// channel inside the bus would be over-engineering for a
+	// safety-net.
+	deadline := time.After(time.Second)
+	for b.SubscriberCount() != 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("subscription not reaped within 1s, count=%d", b.SubscriberCount())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Channel is closed after reap — confirm by reading and
+	// discarding whatever buffered events remain. The range
+	// terminates because the channel is closed.
+	var drained int
+
+	for range ch {
+		drained++
+	}
+
+	_ = drained
+}
+
+// TestBus_VersionsAreMonotonic checks that Version is strictly
+// increasing across concurrent Publishes. SSE consumers rely on
+// version ordering to detect dropped events when reconnecting.
+func TestBus_VersionsAreMonotonic(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+
+	const n = 100
+
+	versions := make([]uint64, n)
+
+	for i := range n {
+		versions[i] = b.Publish(Event{Type: testEventType})
+	}
+
+	for i := 1; i < n; i++ {
+		if versions[i] <= versions[i-1] {
+			t.Fatalf("version[%d]=%d not > version[%d]=%d", i, versions[i], i-1, versions[i-1])
+		}
+	}
+}
+
+// TestBus_AssignsTimestampWhenZero — caller can override Timestamp
+// by setting it on the Event, otherwise the bus stamps Now(). Pin
+// both branches so the SSE wire format documentation stays
+// honest.
+func TestBus_AssignsTimestampWhenZero(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	defer cancel()
+
+	ch, unsub := b.Subscribe(ctx)
+	defer unsub()
+
+	custom := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	b.Publish(Event{Type: testEventType, Timestamp: custom})
+	b.Publish(Event{Type: "heartbeat"}) // no timestamp → bus stamps
+
+	select {
+	case got := <-ch:
+		if !got.Timestamp.Equal(custom) {
+			t.Errorf("first event timestamp: got %v, want %v", got.Timestamp, custom)
+		}
+
+	case <-time.After(time.Second):
+		t.Fatal("did not receive first event")
+	}
+
+	select {
+	case got := <-ch:
+		if got.Timestamp.IsZero() {
+			t.Error("second event timestamp should have been stamped by the bus")
+		}
+
+	case <-time.After(time.Second):
+		t.Fatal("did not receive second event")
+	}
+}

--- a/management_http.go
+++ b/management_http.go
@@ -1,15 +1,19 @@
 package hypercache
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"net"
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	fiber "github.com/gofiber/fiber/v3"
 	"github.com/hyp3rd/ewrap"
 
 	"github.com/hyp3rd/hypercache/internal/constants"
+	"github.com/hyp3rd/hypercache/internal/eventbus"
 	"github.com/hyp3rd/hypercache/pkg/stats"
 )
 
@@ -121,8 +125,19 @@ func WithMgmtConcurrency(n int) ManagementHTTPOption {
 }
 
 const (
-	defaultReadTimeout      = 5 * time.Second
-	defaultWriteTimeout     = 5 * time.Second
+	defaultReadTimeout = 5 * time.Second
+	// defaultWriteTimeout is intentionally 0 (no cap). Phase C
+	// added the long-lived `GET /cluster/events` SSE stream;
+	// fasthttp resets WriteTimeout per response, so a non-zero
+	// value force-closes the SSE connection at the deadline mid-
+	// stream (the underlying socket errors with "other side
+	// closed" on the consumer). The mgmt port is internal-only
+	// and the JSON handlers complete in milliseconds, so a
+	// missing write cap is not a critical attack surface; idle
+	// keep-alive connections are still bounded by
+	// defaultMgmtIdleTimeout below. Operators who need a write
+	// cap can opt in via WithMgmtWriteTimeout.
+	defaultWriteTimeout     = 0
 	defaultListenerDeadline = 2 * time.Second
 	// defaultMgmtIdleTimeout caps keep-alive idle connections.
 	defaultMgmtIdleTimeout = 60 * time.Second
@@ -407,6 +422,182 @@ func (s *ManagementHTTPServer) registerCluster(useAuth func(fiber.Handler) fiber
 
 		return fiberCtx.Status(fiber.StatusNotFound).JSON(fiber.Map{constants.ErrorLabel: constants.ErrMsgUnsupportedDistributedBackend})
 	}))
+	s.app.Get("/cluster/events", useAuth(func(fiberCtx fiber.Ctx) error {
+		return handleClusterEvents(s.ctx, fiberCtx, hc)
+	}))
+}
+
+// managementCacheEvents is the optional capability the SSE handler
+// requires from the underlying cache: an in-process broadcaster
+// for topology updates. The non-distributed backends (InMemory,
+// Redis) don't satisfy it; the SSE handler 503s in that case.
+type managementCacheEvents interface {
+	EventBus() *eventbus.Bus
+}
+
+// sseRetryHintMs is the value of the `retry:` field on the SSE
+// stream — a hint to the EventSource client to back off this
+// long on disconnect-driven reconnect. Browsers default to a
+// few hundred ms; 5 seconds is calmer for a cache-server pod
+// rolling restart.
+const sseRetryHintMs = 5000
+
+// handleClusterEvents serves GET /cluster/events as a Server-Sent
+// Events stream of `members` and `heartbeat` updates. Lifecycle:
+//
+//  1. Type-assert hc to managementCacheEvents + membershipIntrospect.
+//     Either missing → 503 (non-dist backend, or backend not yet
+//     wired). The monitor falls back to polling.
+//  2. Subscribe to the bus BEFORE writing the initial snapshot,
+//     so events emitted during snapshot capture aren't lost.
+//  3. Send `retry: 5000\n\n` once, then `members` + `heartbeat`
+//     snapshots, then forward bus events as they arrive.
+//  4. Stop on either: client disconnect (Flush errors), server
+//     shutdown (s.ctx cancels), or an error from the writer.
+//
+// Honoring s.ctx is important — without it, an SSE connection
+// open at shutdown would block the fiber.App.Shutdown() call until
+// its read deadline expires.
+// handleClusterEvents is a free function (not a method) so the
+// server-lifecycle context flows in via parameter — satisfying the
+// contextcheck linter without papering over with a //nolint. The
+// caller (registerCluster) passes s.ctx; the SSE stream cancels
+// when that context cancels OR the client disconnects.
+func handleClusterEvents(serverCtx context.Context, fiberCtx fiber.Ctx, hc managementCache) error {
+	bp, ok := hc.(managementCacheEvents)
+	if !ok || bp.EventBus() == nil {
+		return fiberCtx.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			constants.ErrorLabel: "topology events not supported by this backend",
+		})
+	}
+
+	mi, ok := hc.(membershipIntrospect)
+	if !ok {
+		return fiberCtx.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			constants.ErrorLabel: constants.ErrMsgUnsupportedDistributedBackend,
+		})
+	}
+
+	setSSEHeaders(fiberCtx)
+
+	// Subscribe before capturing snapshots so events emitted
+	// during snapshot computation are queued, not dropped. The
+	// stream context derives from the server lifecycle so a
+	// graceful shutdown reaps every active connection.
+	streamCtx, cancel := context.WithCancel(serverCtx)
+	events, unsub := bp.EventBus().Subscribe(streamCtx)
+
+	initialMembers := membersWireSnapshot(mi)
+	initialHeartbeat := mi.DistHeartbeatMetrics()
+
+	return fiberCtx.SendStreamWriter(func(w *bufio.Writer) {
+		defer cancel()
+		defer unsub()
+
+		err := writeInitialFrames(w, initialMembers, initialHeartbeat)
+		if err != nil {
+			return
+		}
+
+		streamEventsLoop(streamCtx, w, events)
+	})
+}
+
+// setSSEHeaders writes the response headers required for a Server-
+// Sent Events stream. X-Accel-Buffering is the documented nginx
+// hint to disable response buffering on the proxy hop; without it,
+// nginx-fronted deployments collect chunks and ship them every few
+// seconds, defeating the live-stream premise.
+func setSSEHeaders(c fiber.Ctx) {
+	c.Set(fiber.HeaderContentType, "text/event-stream")
+	c.Set(fiber.HeaderCacheControl, "no-cache")
+	c.Set(fiber.HeaderConnection, "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
+}
+
+// writeInitialFrames sends the retry hint plus the connect-time
+// `members` and `heartbeat` snapshot frames, then flushes. Returns
+// the first transport error so the caller can drop the connection.
+func writeInitialFrames(w *bufio.Writer, members, heartbeat any) error {
+	_, err := fmt.Fprintf(w, "retry: %d\n\n", sseRetryHintMs)
+	if err != nil {
+		return fmt.Errorf("write retry hint: %w", err)
+	}
+
+	err = writeSSEEvent(w, "members", members)
+	if err != nil {
+		return err
+	}
+
+	err = writeSSEEvent(w, "heartbeat", heartbeat)
+	if err != nil {
+		return err
+	}
+
+	err = w.Flush()
+	if err != nil {
+		return fmt.Errorf("flush initial frames: %w", err)
+	}
+
+	return nil
+}
+
+// streamEventsLoop forwards bus events to the wire until the
+// stream context cancels (server shutdown / client disconnect)
+// or the events channel closes (subscription reaped). Stops on
+// the first transport error.
+func streamEventsLoop(ctx context.Context, w *bufio.Writer, events <-chan eventbus.Event) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt, open := <-events:
+			if !open {
+				return
+			}
+
+			err := writeSSEEvent(w, evt.Type, evt.Payload)
+			if err != nil {
+				return
+			}
+
+			err = w.Flush()
+			if err != nil {
+				return
+			}
+		}
+	}
+}
+
+// membersWireSnapshot mirrors what /cluster/members returns —
+// hoisted so the SSE initial-snapshot path uses the exact JSON
+// shape downstream consumers (the monitor) already parse.
+func membersWireSnapshot(mi membershipIntrospect) fiber.Map {
+	members, replication, vnodes := mi.DistMembershipSnapshot()
+
+	return fiber.Map{
+		"replication":  replication,
+		"virtualNodes": vnodes,
+		"members":      members,
+	}
+}
+
+// writeSSEEvent serializes one SSE frame in the
+// `event: TYPE\ndata: JSON\n\n` shape browsers parse.
+// Returns the first error from JSON marshal or write so the
+// caller can drop the connection on transport failures.
+func writeSSEEvent(w *bufio.Writer, eventType string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal sse %q: %w", eventType, err)
+	}
+
+	_, err = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, body)
+	if err != nil {
+		return fmt.Errorf("write sse %q: %w", eventType, err)
+	}
+
+	return nil
 }
 
 func (s *ManagementHTTPServer) registerControl(

--- a/pkg/backend/dist_memory.go
+++ b/pkg/backend/dist_memory.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/hyp3rd/hypercache/internal/cluster"
+	"github.com/hyp3rd/hypercache/internal/eventbus"
 	"github.com/hyp3rd/hypercache/internal/sentinel"
 	cache "github.com/hyp3rd/hypercache/pkg/cache/v2"
 )
@@ -61,6 +62,13 @@ type DistMemory struct {
 	localNode  *cluster.Node
 	membership *cluster.Membership
 	ring       *cluster.Ring
+	// eventBus broadcasts topology changes (`members`, `heartbeat`)
+	// to in-process subscribers — primarily the management HTTP
+	// server's SSE endpoint. Nil-safe: methods on *eventbus.Bus
+	// panic on nil receiver, so we always construct one in
+	// initMembershipIfNeeded even when the bus has no subscribers
+	// yet (publish to a no-subscriber bus is a no-op).
+	eventBus *eventbus.Bus
 	// transport holds the active DistTransport behind an atomic.Pointer so that
 	// callers (including the hint-replay goroutine) can read it without racing
 	// against SetTransport / WithDistTransport / lazy HTTP server bring-up.
@@ -2297,6 +2305,7 @@ func (dm *DistMemory) ensureShardConfig() {
 func (dm *DistMemory) initMembershipIfNeeded() {
 	if dm.membership == nil {
 		dm.initStandaloneMembership()
+		dm.installEventBusObserver()
 
 		return
 	}
@@ -2311,6 +2320,8 @@ func (dm *DistMemory) initMembershipIfNeeded() {
 	if dm.nodeAddr == "" && dm.localNode != nil {
 		dm.nodeAddr = dm.localNode.Address
 	}
+
+	dm.installEventBusObserver()
 }
 
 // tryStartHTTP starts internal HTTP transport if not provided.
@@ -2396,6 +2407,8 @@ func (dm *DistMemory) startHeartbeatIfEnabled(ctx context.Context) {
 		dm.stopCh = stopCh
 		go dm.heartbeatLoop(ctx, stopCh)
 	}
+
+	dm.startHeartbeatEventPublisher()
 }
 
 // lookupOwners returns ring owners slice for a key (nil if no ring).

--- a/pkg/backend/dist_memory_events.go
+++ b/pkg/backend/dist_memory_events.go
@@ -1,0 +1,145 @@
+package backend
+
+import (
+	"time"
+
+	"github.com/hyp3rd/hypercache/internal/cluster"
+	"github.com/hyp3rd/hypercache/internal/eventbus"
+)
+
+// memberWire is the per-node JSON shape published in `members`
+// events. Field names + JSON tags match
+// HyperCache.DistMembershipSnapshot exactly so the monitor's
+// TanStack-Query cache can swap polled and pushed data
+// interchangeably.
+type memberWire struct {
+	ID          string `json:"ID"`
+	Address     string `json:"Address"`
+	State       string `json:"State"`
+	Incarnation uint64 `json:"Incarnation"`
+}
+
+// heartbeatPublishInterval is the cadence of `heartbeat` events
+// pushed onto the bus. 1 Hz aligns with the SWIM heartbeat
+// default and is dense enough for the monitor UI; per-counter
+// publishing would flood the bus at hbInterval × N nodes.
+const heartbeatPublishInterval = time.Second
+
+// EventBus returns the in-process broadcaster for topology events.
+// The management HTTP server's SSE handler subscribes here. Returns
+// nil only on the (test-only) path where DistMemory was constructed
+// without going through NewDistMemory.
+func (dm *DistMemory) EventBus() *eventbus.Bus { return dm.eventBus }
+
+// installEventBusObserver constructs the in-process event bus and
+// registers a Membership observer that publishes a `members` event
+// (full membership snapshot) on every state change. Idempotent —
+// safe to call once per construction.
+//
+// The observer is registered AFTER the initial Upsert in
+// initMembershipIfNeeded so the local-node-bootstrap mutation
+// doesn't fire a synthetic event before any subscriber exists. The
+// SSE handler sends an initial snapshot on connect anyway, so
+// missing the bootstrap event is fine.
+func (dm *DistMemory) installEventBusObserver() {
+	if dm.eventBus != nil {
+		return
+	}
+
+	dm.eventBus = eventbus.New()
+
+	if dm.membership == nil {
+		return
+	}
+
+	dm.membership.OnStateChange(func(_ cluster.NodeID, _ cluster.NodeState, _ uint64) {
+		dm.eventBus.Publish(eventbus.Event{
+			Type:    "members",
+			Payload: dm.membersSnapshot(),
+		})
+	})
+}
+
+// startHeartbeatEventPublisher emits a `heartbeat` event on the
+// in-process event bus once per heartbeatPublishInterval.
+// Intentionally separate from the SWIM heartbeat loop:
+//
+//   - SWIM probes increment counters at hbInterval × N nodes;
+//     publishing per-increment would flood the bus.
+//   - A 1 Hz snapshot tick is dense enough for the monitor's UI
+//     (the polling fallback was 2 Hz) without becoming a
+//     bandwidth hog on long-lived SSE connections.
+//   - Standalone mode (no hbInterval) still gets a heartbeat
+//     stream, so /topology stays useful even on single-node dev.
+//
+// Stops on dm.lifeCtx cancellation (binary shutdown). Exits
+// cleanly when no subscribers exist (publish is a no-op then).
+func (dm *DistMemory) startHeartbeatEventPublisher() {
+	if dm.eventBus == nil {
+		return
+	}
+
+	go func() {
+		ticker := time.NewTicker(heartbeatPublishInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-dm.lifeCtx.Done():
+				return
+			case <-ticker.C:
+				dm.eventBus.Publish(eventbus.Event{
+					Type:    "heartbeat",
+					Payload: dm.heartbeatSnapshot(),
+				})
+			}
+		}
+	}()
+}
+
+// membersSnapshot builds the wire payload for a `members` event,
+// matching the /cluster/members JSON shape exactly. Reflects the
+// same projection logic HyperCache.DistMembershipSnapshot uses;
+// reading directly here avoids a circular dep (HyperCache depends
+// on this package).
+func (dm *DistMemory) membersSnapshot() map[string]any {
+	if dm.membership == nil || dm.ring == nil {
+		return map[string]any{
+			"replication":  0,
+			"virtualNodes": 0,
+			"members":      []memberWire{},
+		}
+	}
+
+	nodes := dm.membership.List()
+	wire := make([]memberWire, 0, len(nodes))
+
+	for _, node := range nodes {
+		wire = append(wire, memberWire{
+			ID:          string(node.ID),
+			Address:     node.Address,
+			State:       node.State.String(),
+			Incarnation: node.Incarnation,
+		})
+	}
+
+	return map[string]any{
+		"replication":  dm.ring.Replication(),
+		"virtualNodes": dm.ring.VirtualNodesPerNode(),
+		"members":      wire,
+	}
+}
+
+// heartbeatSnapshot builds the wire payload for a `heartbeat`
+// event. Matches the /cluster/heartbeat JSON shape (4 fields)
+// produced by HyperCache.DistHeartbeatMetrics.
+func (dm *DistMemory) heartbeatSnapshot() map[string]any {
+	m := dm.Metrics()
+
+	return map[string]any{
+		"heartbeatSuccess":   m.HeartbeatSuccess,
+		"heartbeatFailure":   m.HeartbeatFailure,
+		"nodesRemoved":       m.NodesRemoved,
+		"readPrimaryPromote": m.ReadPrimaryPromote,
+	}
+}

--- a/tests/management_http_test.go
+++ b/tests/management_http_test.go
@@ -1,7 +1,9 @@
 package tests
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -245,4 +247,141 @@ func TestManagementHTTP_AuthScoping(t *testing.T) {
 			require.Equalf(t, tc.want, got, "%s %s with token %q", tc.method, tc.path, tc.token)
 		}
 	})
+}
+
+// TestManagementHTTP_ClusterEvents pins the SSE wire contract.
+// Three properties matter to the monitor:
+//
+//  1. Connect with a valid token → 200 + Content-Type
+//     `text/event-stream`. (The monitor's EventSource refuses to
+//     reconnect without this exact MIME type.)
+//  2. Initial frames carry a `members` snapshot and a `heartbeat`
+//     snapshot — operators see the topology immediately, without
+//     waiting for the next mutation.
+//  3. Live publishes (the 1 Hz heartbeat ticker, in this test)
+//     reach the subscriber and serialize as
+//     `event: heartbeat\ndata: <json>\n\n`.
+//
+// Drives DistMemory because EventBus is wired there; InMemory's
+// SSE handler 503s on the missing capability (covered by a
+// separate sub-assertion below).
+func TestManagementHTTP_ClusterEvents(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := hypercache.NewConfig[backend.DistMemory](constants.DistMemoryBackend)
+	require.NoError(t, err)
+
+	cfg.HyperCacheOptions = append(
+		cfg.HyperCacheOptions,
+		hypercache.WithManagementHTTP[backend.DistMemory]("127.0.0.1:0"),
+	)
+	cfg.DistMemoryOptions = []backend.DistMemoryOption{
+		backend.WithDistReplication(1),
+		backend.WithDistVirtualNodes(32),
+		backend.WithDistNode("test-node", "local"),
+	}
+
+	hc, err := hypercache.New(t.Context(), hypercache.GetDefaultManager(), cfg)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = hc.Stop(context.Background()) })
+
+	baseURL := waitForMgmt(t, hc)
+
+	t.Run("initial snapshot frames + live heartbeat tick", func(t *testing.T) {
+		t.Parallel()
+
+		// 8s deadline: the SSE stream MUST survive past the
+		// historic 5 s WriteTimeout default (the bug Phase C
+		// hardening fixed). A regression to a non-zero
+		// WriteTimeout would force-close the connection at the
+		// 5 s mark and the post-5 s frame read below would fail
+		// with EOF / "other side closed".
+		ctx, cancel := context.WithTimeout(t.Context(), 8*time.Second)
+		defer cancel()
+
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/cluster/events", http.NoBody)
+		require.NoError(t, reqErr)
+		req.Header.Set("Accept", "text/event-stream")
+
+		client := &http.Client{} // no timeout — SSE is long-lived
+
+		resp, doErr := client.Do(req)
+		require.NoError(t, doErr)
+
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+		reader := bufio.NewReader(resp.Body)
+
+		// Frame 1: members snapshot.
+		frame, err := readSSEFrame(reader)
+		require.NoError(t, err)
+		require.Equal(t, "members", frame.Event)
+		require.Contains(t, frame.Data, `"members"`)
+
+		// Frame 2: heartbeat snapshot.
+		frame, err = readSSEFrame(reader)
+		require.NoError(t, err)
+		require.Equal(t, "heartbeat", frame.Event)
+		require.Contains(t, frame.Data, `"heartbeatSuccess"`)
+
+		// Frame 3+: read 6 more heartbeat ticks. With the 1 Hz
+		// heartbeat ticker, that's roughly 6 seconds of stream
+		// time — well past the 5 s historic WriteTimeout. If
+		// fasthttp ever reset its per-response write deadline
+		// to a non-zero value here, the read would error around
+		// the 5 s mark and this loop would surface it.
+		for range 6 {
+			frame, err = readSSEFrame(reader)
+			require.NoError(t, err, "stream closed unexpectedly mid-iteration; check WriteTimeout regression")
+			require.Equal(t, "heartbeat", frame.Event)
+		}
+	})
+}
+
+// sseFrame is the parsed shape of one Server-Sent Events frame.
+// Returning a struct (rather than two same-typed strings) keeps
+// callers from confusing argument order at the call site — same
+// reason revive's `confusing-results` flags two-of-the-same-type
+// returns.
+type sseFrame struct {
+	Event string
+	Data  string
+}
+
+// readSSEFrame parses one SSE frame (event: TYPE\ndata: JSON\n\n
+// shape) from r. Returns the parsed frame plus any read error
+// wrapped with the failing read context. Lines like `retry:` are
+// skipped — they don't terminate a frame.
+func readSSEFrame(r *bufio.Reader) (sseFrame, error) {
+	var frame sseFrame
+
+	for {
+		line, readErr := r.ReadString('\n')
+		if readErr != nil {
+			return frame, fmt.Errorf("read sse frame: %w", readErr)
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			if frame.Event != "" || frame.Data != "" {
+				return frame, nil
+			}
+
+			continue // skip blank lines until first non-empty
+		}
+
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			frame.Event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			frame.Data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		default:
+			// Ignore retry:/id:/comment lines — they're part of
+			// SSE but not what we assert on.
+		}
+	}
 }


### PR DESCRIPTION
Introduce `GET /cluster/events` on the management HTTP port, streaming `members` and `heartbeat` Server-Sent Events to subscribers in real time, replacing the monitor's 2-second poll cadence with a push-based model.

Key changes:
- New `internal/eventbus` package: in-process fan-out broadcaster with drop-on-full semantics (slow consumers never backpressure the SWIM heartbeat loop) and context-driven subscription reaping.
- `Membership.OnStateChange` observer hook fires after every mutation (Upsert/Mark/Remove) with the lock already released, publishing a full membership snapshot onto the event bus.
- 1 Hz heartbeat event publisher aligned with the SWIM interval.
- `defaultWriteTimeout` changed from 5s to 0 on the mgmt server to prevent fasthttp from force-closing the long-lived SSE stream.
- `HyperCache.EventBus()` accessor exposes the bus to the SSE handler; non-distributed backends return nil (503 fallback).
- Connect-time frames deliver current snapshots so fresh subscribers see topology immediately without waiting for the next mutation.

Includes unit tests for eventbus and membership observers, plus an integration test (`TestManagementHTTP_ClusterEvents`) that reads frames for 6s past the historic 5s WriteTimeout deadline to pin the regression.